### PR TITLE
Quack implemention

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -93,6 +93,7 @@ RSpec/DescribeClass:
     - spec/active_record/connection_adapters/duckdb/ducklake_migration_spec.rb
     - spec/active_record/connection_adapters/duckdb/ducklake_schema_compatibility_spec.rb
     - spec/active_record/connection_adapters/duckdb/quack_spec.rb
+    - spec/active_record/connection_adapters/duckdb/quack_integer_pk_spec.rb
     - spec/active_record/connection_adapters/duckdb/schema_dumper_spec.rb
     - spec/active_record/connection_adapters/duckdb/timestamp_timezone_spec.rb
     - spec/active_record/connection_adapters/duckdb/transaction_spec.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -92,6 +92,7 @@ RSpec/DescribeClass:
     - spec/ducklake_spec.rb
     - spec/active_record/connection_adapters/duckdb/ducklake_migration_spec.rb
     - spec/active_record/connection_adapters/duckdb/ducklake_schema_compatibility_spec.rb
+    - spec/active_record/connection_adapters/duckdb/quack_spec.rb
     - spec/active_record/connection_adapters/duckdb/schema_dumper_spec.rb
     - spec/active_record/connection_adapters/duckdb/timestamp_timezone_spec.rb
     - spec/active_record/connection_adapters/duckdb/transaction_spec.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add optional support for connecting to a remote DuckDB server via the quack protocol (`quack:` config block, off by default)
 - Add a quack server launcher (`QuackServer` class and `rake duckdb:quack:serve` task) so multiple processes can share one writable DuckDB database
 - Support ordinary integer (auto-increment) primary keys over quack: prefetch ids from the server sequence, create tables without a `nextval` column default, and route INSERT/UPDATE/DELETE so ActiveRecord CRUD works transparently against a remote quack server
+- Gracefully stop the quack server: `QuackServer#stop` now calls quack's in-band `quack_stop()` (closing the connection alone does not stop the listener), and `QuackServer#wait` / the `duckdb:quack:serve` task shut down on SIGINT and SIGTERM
 
 ## [0.1.1] - 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 - Add optional support for connecting to a remote DuckDB server via the quack protocol (`quack:` config block, off by default)
+- Add a quack server launcher (`QuackServer` class and `rake duckdb:quack:serve` task) so multiple processes can share one writable DuckDB database
 
 ## [0.1.1] - 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add optional support for connecting to a remote DuckDB server via the quack protocol (`quack:` config block, off by default)
 - Add a quack server launcher (`QuackServer` class and `rake duckdb:quack:serve` task) so multiple processes can share one writable DuckDB database
+- Support ordinary integer (auto-increment) primary keys over quack: prefetch ids from the server sequence, create tables without a `nextval` column default, and route INSERT/UPDATE/DELETE so ActiveRecord CRUD works transparently against a remote quack server
 
 ## [0.1.1] - 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Add optional support for connecting to a remote DuckDB server via the quack protocol (`quack:` config block, off by default)
+
 ## [0.1.1] - 2026-07-08
 
 - Cleanup code so all linters pass

--- a/README.md
+++ b/README.md
@@ -292,6 +292,35 @@ Notes:
   the adapter's secure defaults remain in effect. The explicit `INSTALL` performs a one-time
   network fetch of the extension on first connection.
 
+##### Schema, migrations, and integer primary keys over quack
+
+Ordinary integer (auto-increment) primary keys work over quack — no need to switch your app to
+UUIDs. The adapter adapts transparently because a quack `ATTACH` has some hard constraints:
+
+- A column with a function-valued `DEFAULT` (such as `nextval(...)`) breaks `ATTACH`, and the
+  client cannot see the server's sequences through the attached catalog.
+- `INSERT ... RETURNING`, `UPDATE`, and `DELETE` are not supported directly on an attached quack
+  table.
+
+To make Rails work anyway, in quack mode the adapter:
+
+- Creates tables **without** a `DEFAULT nextval()` column default, and creates the backing
+  sequence on the server via quack's server-side query channel.
+- **Prefetches** the next id from that sequence and includes it in the `INSERT` (so no
+  `RETURNING` is needed).
+- Routes `UPDATE`/`DELETE` to the server the same way, returning the affected-row count.
+
+**Run your migrations through the quack connection.** Point Rails at the quack server (a
+`quack:` block in `database.yml`) and run `rails db:migrate` as usual — `create_table` builds the
+schema on the server in the quack-compatible shape. After that, `Model.create`, `find`, `where`,
+`update`, and `destroy` all behave normally:
+
+```ruby
+User.create!(name: "alice")   # => #<User id: 1, ...>  (id prefetched from the server sequence)
+User.where(name: "alice").update_all(active: true)
+User.last.destroy
+```
+
 ##### Running a quack server
 
 The real value of quack is letting **multiple separate processes** (e.g. several Rails/Puma

--- a/README.md
+++ b/README.md
@@ -328,19 +328,32 @@ workers, Sidekiq, and a console) share **one writable** DuckDB database concurre
 embedded/in-process DuckDB cannot do because of its single-writer file lock. To get that, run a
 **dedicated, long-lived server process** and point every app process at it as a client.
 
-This gem ships a rake task and a `QuackServer` class to launch one:
+This gem ships a rake task and a `QuackServer` class to launch one.
+
+**Rake task**
 
 ```bash
-# Serve a file-backed database so its data survives restarts
+bundle exec rake duckdb:quack:serve
+```
+
+Starts a long-lived quack server in the foreground and blocks until it receives SIGINT (Ctrl-C) or
+SIGTERM. It is configured through environment variables:
+
+| Variable                    | Default                 | Description                                             |
+| --------------------------- | ----------------------- | ------------------------------------------------------- |
+| `DATABASE`                  | `:memory:`              | File path to serve, or `:memory:`                       |
+| `BIND`                      | `quack:localhost:9494`  | Bind URI                                                |
+| `QUACK_TOKEN`               | —                       | Auth token (min. 4 chars); if unset the server generates one and allows all queries |
+| `QUACK_EXTENSIONS`          | —                       | Extra extensions to load, comma-separated               |
+| `QUACK_ALLOW_OTHER_HOSTNAME`| —                       | Set to `1` to bind a non-localhost address (e.g. `0.0.0.0`) |
+
+```bash
+# Serve a file-backed database (its data survives restarts) on a public address
 DATABASE=db/shared.duckdb BIND=quack:0.0.0.0:9494 QUACK_TOKEN=super_secret \
   QUACK_ALLOW_OTHER_HOSTNAME=1 bundle exec rake duckdb:quack:serve
 ```
 
-Environment variables: `DATABASE` (file path or `:memory:`, default `:memory:`), `BIND`
-(default `quack:localhost:9494`), `QUACK_TOKEN`, `QUACK_EXTENSIONS` (comma-separated), and
-`QUACK_ALLOW_OTHER_HOSTNAME=1` (required to bind a non-localhost address such as `0.0.0.0`).
-
-Or from Ruby:
+**Or from Ruby**
 
 ```ruby
 server = ActiveRecord::ConnectionAdapters::Duckdb::QuackServer.new(
@@ -349,8 +362,16 @@ server = ActiveRecord::ConnectionAdapters::Duckdb::QuackServer.new(
   token: ENV['QUACK_TOKEN']
 )
 server.start # non-blocking; the listener runs in a background thread
-server.wait  # keep this process alive (Ctrl-C to stop)
+server.wait  # keep this process alive until SIGINT/SIGTERM
+server.stop  # gracefully stop serving (quack_stop) and close the connection
 ```
+
+**Stopping the server.** The server stops gracefully on **Ctrl-C (SIGINT)** or **SIGTERM** — the
+signal `kill`, Docker, systemd, and foreman send — so a process manager can shut it down cleanly.
+`QuackServer#stop` calls quack's in-band `quack_stop()`; simply closing the connection does **not**
+stop the listener. Because `quack_stop()` only affects the server within its own process, there is
+no separate "stop" rake task — stop the serving process the usual way (Ctrl-C, `kill <pid>`, or your
+process manager) and the shutdown is handled gracefully.
 
 Important:
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,65 @@ development:
   use_database: analytics # Switch to the attached database
 ```
 
+#### Remote Server (quack protocol)
+
+DuckDB 1.5.3+ ships the [quack](https://duckdb.org/quack/) core extension, which lets an
+embedded DuckDB act as a **client** to a remote DuckDB **server** over the `quack:` protocol
+(HTTP, default port `9494`). This adapter can connect to such a server through an optional
+`quack:` configuration block.
+
+This feature is **off by default**. When the `quack:` block is absent, the adapter continues to
+use a standalone file-based or in-memory database exactly as before.
+
+On the server, start a DuckDB instance serving over quack:
+
+```sql
+CALL quack_serve('quack:0.0.0.0:9494', token = 'super_secret');
+```
+
+Then point the adapter at it. The local `database:` acts as the client's control database
+(in-memory is typical); the remote server's data is reached through the attached alias:
+
+```yaml
+production:
+  adapter: duckdb
+  database: ":memory:"                       # local client control database
+  quack:
+    url: "quack:analytics.example.com:9494"   # required: remote server URI
+    token: <%= ENV["QUACK_TOKEN"] %>          # optional: auth token
+    as: remote                                # optional: ATTACH alias (default: remote)
+    use: true                                 # optional: USE the attached db (default: true)
+```
+
+The adapter installs and loads the quack extension for you, so you do **not** need to add it to
+the `extensions:` list. Under the hood, a populated block emits (in order):
+
+```sql
+INSTALL quack;
+LOAD quack;
+CREATE SECRET (TYPE quack, TOKEN 'super_secret', SCOPE 'quack:analytics.example.com:9494'); -- only when a token is given
+ATTACH 'quack:analytics.example.com:9494' AS remote (TYPE quack);
+USE remote;                                                                                  -- unless use: false
+```
+
+Configuration options:
+
+| Option  | Required | Default  | Description                                                     |
+| ------- | -------- | -------- | --------------------------------------------------------------- |
+| `url`   | yes      | —        | Remote server URI, e.g. `"quack:host:9494"`                     |
+| `token` | no       | —        | Auth token; registered as a scoped quack `SECRET` when present  |
+| `as`    | no       | `remote` | Alias used by `ATTACH ... AS <as>`                              |
+| `use`   | no       | `true`   | Whether to `USE` the attached database after attaching          |
+
+Notes:
+
+- A `quack:` block that is empty, or whose keys are all blank, is treated as disabled (no-op).
+- A block that provides other keys but omits `url` raises an error rather than producing an
+  invalid connection.
+- Because quack is a **core** extension, no `allow_community_extensions` relaxation is needed and
+  the adapter's secure defaults remain in effect. The explicit `INSTALL` performs a one-time
+  network fetch of the extension on first connection.
+
 ### Sample App setup
 
 The following steps are required to setup a sample application using the `activerecord-duckdb` gem:

--- a/README.md
+++ b/README.md
@@ -240,11 +240,14 @@ embedded DuckDB act as a **client** to a remote DuckDB **server** over the `quac
 This feature is **off by default**. When the `quack:` block is absent, the adapter continues to
 use a standalone file-based or in-memory database exactly as before.
 
-On the server, start a DuckDB instance serving over quack:
+On the server, start a DuckDB instance serving over quack. You can do this in raw SQL:
 
 ```sql
-CALL quack_serve('quack:0.0.0.0:9494', token = 'super_secret');
+CALL quack_serve('quack:0.0.0.0:9494', token => 'super_secret', allow_other_hostname => true);
 ```
+
+...or use the launcher this gem provides (see [Running a quack server](#running-a-quack-server)
+below).
 
 Then point the adapter at it. The local `database:` acts as the client's control database
 (in-memory is typical); the remote server's data is reached through the attached alias:
@@ -288,6 +291,49 @@ Notes:
 - Because quack is a **core** extension, no `allow_community_extensions` relaxation is needed and
   the adapter's secure defaults remain in effect. The explicit `INSTALL` performs a one-time
   network fetch of the extension on first connection.
+
+##### Running a quack server
+
+The real value of quack is letting **multiple separate processes** (e.g. several Rails/Puma
+workers, Sidekiq, and a console) share **one writable** DuckDB database concurrently — something
+embedded/in-process DuckDB cannot do because of its single-writer file lock. To get that, run a
+**dedicated, long-lived server process** and point every app process at it as a client.
+
+This gem ships a rake task and a `QuackServer` class to launch one:
+
+```bash
+# Serve a file-backed database so its data survives restarts
+DATABASE=db/shared.duckdb BIND=quack:0.0.0.0:9494 QUACK_TOKEN=super_secret \
+  QUACK_ALLOW_OTHER_HOSTNAME=1 bundle exec rake duckdb:quack:serve
+```
+
+Environment variables: `DATABASE` (file path or `:memory:`, default `:memory:`), `BIND`
+(default `quack:localhost:9494`), `QUACK_TOKEN`, `QUACK_EXTENSIONS` (comma-separated), and
+`QUACK_ALLOW_OTHER_HOSTNAME=1` (required to bind a non-localhost address such as `0.0.0.0`).
+
+Or from Ruby:
+
+```ruby
+server = ActiveRecord::ConnectionAdapters::Duckdb::QuackServer.new(
+  database: 'db/shared.duckdb',
+  bind: 'quack:localhost:9494',
+  token: ENV['QUACK_TOKEN']
+)
+server.start # non-blocking; the listener runs in a background thread
+server.wait  # keep this process alive (Ctrl-C to stop)
+```
+
+Important:
+
+- **Run the server as its own process, not inside your Rails app's connection.** Do not try to
+  serve and connect as a client from the *same* process — beyond offering no benefit (you'd be
+  routing queries over an HTTP loopback to a database you could query directly), it is unstable
+  at process teardown. Server and clients must be **separate processes**.
+- Auth tokens must be **at least 4 characters**; `QuackServer` raises early if a shorter one is
+  given. If no token is set, the server generates one at startup and (by default) allows all
+  queries — set a token for anything beyond local experimentation.
+- When binding a public address, front the server with a TLS-terminating reverse proxy (e.g.
+  nginx) rather than exposing quack directly, as the DuckDB documentation recommends.
 
 ### Sample App setup
 

--- a/lib/active_record/connection_adapters/duckdb/quack_server.rb
+++ b/lib/active_record/connection_adapters/duckdb/quack_server.rb
@@ -32,6 +32,9 @@ module ActiveRecord
         # Minimum token length enforced by the quack server.
         MIN_TOKEN_LENGTH = 4
 
+        # Signals that trigger a graceful shutdown from {#wait}.
+        SHUTDOWN_SIGNALS = %w[INT TERM].freeze
+
         # @return [String] the database opened and served (file path or ':memory:')
         attr_reader :database
         # @return [String] the quack bind URI, e.g. "quack:localhost:9494"
@@ -103,23 +106,51 @@ module ActiveRecord
           self
         end
 
-        # Blocks the current thread indefinitely to keep the background listener
-        # alive. Returns when interrupted (e.g. Ctrl-C).
+        # Blocks the current thread to keep the background listener alive, returning
+        # when the process is asked to stop. Handles both SIGINT (Ctrl-C) and SIGTERM
+        # (the signal `kill`, Docker, systemd, and foreman send) so the caller can run
+        # {#stop} for a graceful shutdown afterwards.
         # @return [void]
         def wait
-          sleep
+          running = true
+          # A finite sleep loop rather than a blocking wait: the quack listener is a
+          # native thread invisible to Ruby, so a blocking Queue/`sleep`-forever on the
+          # sole Ruby thread would trip the deadlock detector. A trapped signal both
+          # flips the flag and interrupts the current sleep, so shutdown is prompt.
+          previous = SHUTDOWN_SIGNALS.to_h { |sig| [sig, Signal.trap(sig) { running = false }] }
+          sleep(1) while running
         rescue Interrupt
           nil
+        ensure
+          previous&.each { |sig, handler| Signal.trap(sig, handler || 'DEFAULT') }
         end
 
         # Stops serving and closes the connection.
+        #
+        # Closing the connection alone does NOT stop the quack listener, so this first
+        # asks the server to stop via quack_stop(); otherwise the listener would keep
+        # accepting clients until the process exits.
         # @return [void]
         def stop
+          stop_serving
           @connection&.close
           @connection = nil
         end
 
         private
+
+        # Asks the server to stop serving every URI it is currently bound to. Safe to
+        # call when nothing is being served.
+        # @return [void]
+        def stop_serving
+          return unless @connection
+
+          @connection.query('SELECT * FROM quack_server_list()').to_a.each do |row|
+            @connection.query("CALL quack_stop(#{quote(row.first)})")
+          end
+        rescue DuckDB::Error
+          nil
+        end
 
         # @return [Boolean] whether the served database is in-memory
         def memory?

--- a/lib/active_record/connection_adapters/duckdb/quack_server.rb
+++ b/lib/active_record/connection_adapters/duckdb/quack_server.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module Duckdb
+      # Launches a DuckDB instance as a quack server so that multiple *separate*
+      # client processes can share one database with concurrent reads and writes.
+      #
+      # This is deliberately decoupled from the per-connection client configuration
+      # (see +DuckdbAdapter#configure_quack+). A quack server is long-lived shared
+      # infrastructure meant to run as its own process; it is *not* something to spin
+      # up inside a pooled ActiveRecord connection (each pooled connection would try to
+      # bind the same port and would serve its own separate database).
+      #
+      # The server opens the database file and serves it over the +quack:+ protocol;
+      # clients then connect to the server (see the +quack:+ config block) rather than
+      # opening the file directly. This is what lets multiple processes write to one
+      # DuckDB database, which embedded/in-process DuckDB cannot do on its own.
+      #
+      # @example Start a server from Ruby
+      #   server = ActiveRecord::ConnectionAdapters::Duckdb::QuackServer.new(
+      #     database: 'db/shared.duckdb',
+      #     bind: 'quack:localhost:9494',
+      #     token: ENV['QUACK_TOKEN']
+      #   )
+      #   server.start   # non-blocking: the listener runs in a background thread
+      #   server.wait    # block the current process to keep the listener alive
+      class QuackServer
+        # Default bind URI: localhost on the standard quack port.
+        DEFAULT_BIND = 'quack:localhost:9494'
+
+        # Minimum token length enforced by the quack server.
+        MIN_TOKEN_LENGTH = 4
+
+        # @return [String] the database opened and served (file path or ':memory:')
+        attr_reader :database
+        # @return [String] the quack bind URI, e.g. "quack:localhost:9494"
+        attr_reader :bind
+        # @return [String, nil] the auth token clients must present, if any
+        attr_reader :token
+        # @return [Array<String>] extra extensions to INSTALL/LOAD before serving
+        attr_reader :extensions
+        # @return [Boolean] whether to allow binding a non-local hostname
+        attr_reader :allow_other_hostname
+        # @return [DuckDB::Connection, nil] the serving connection once started
+        attr_reader :connection
+
+        # @param database [String] file path to serve, or ':memory:' (default)
+        # @param bind [String] quack bind URI (default: {DEFAULT_BIND})
+        # @param token [String, nil] auth token required from clients
+        # @param extensions [Array<String>] extra extensions to load before serving
+        # @param allow_other_hostname [Boolean] pass allow_other_hostname to quack_serve
+        #   (required when binding a non-localhost address such as 0.0.0.0)
+        def initialize(database: ':memory:', bind: DEFAULT_BIND, token: nil,
+                       extensions: [], allow_other_hostname: false)
+          @database = database.to_s.empty? ? ':memory:' : database.to_s
+          @bind = bind.presence || DEFAULT_BIND
+          @token = token.presence
+          @extensions = Array(extensions).compact
+          @allow_other_hostname = allow_other_hostname
+          @connection = nil
+
+          return unless @token && @token.length < MIN_TOKEN_LENGTH
+
+          raise ArgumentError,
+                "quack server token must be at least #{MIN_TOKEN_LENGTH} characters long"
+        end
+
+        # Builds the SQL statements executed on startup, in order.
+        # Exposed separately so it can be asserted in tests without a live server.
+        # @return [Array<String>] SQL statements
+        def startup_sql
+          sql = ['INSTALL quack', 'LOAD quack']
+          extensions.each do |extension|
+            sql << "INSTALL #{extension}"
+            sql << "LOAD #{extension}"
+          end
+          sql << serve_sql
+          sql
+        end
+
+        # Builds the CALL quack_serve(...) statement.
+        # @return [String] the serve SQL
+        def serve_sql
+          params = []
+          params << "token => #{quote(token)}" if token
+          params << 'allow_other_hostname => true' if allow_other_hostname
+
+          serve = "CALL quack_serve(#{quote(bind)}"
+          serve << ", #{params.join(", ")}" unless params.empty?
+          serve << ')'
+          serve
+        end
+
+        # Opens the database, loads quack, and begins serving. Non-blocking: the
+        # quack listener runs in a background thread, so this returns once serving
+        # has started. Use {#wait} to keep the owning process alive.
+        # @return [self]
+        def start
+          db = memory? ? DuckDB::Database.open : DuckDB::Database.open(database)
+          @connection = db.connect
+          startup_sql.each { |statement| @connection.execute(statement) }
+          self
+        end
+
+        # Blocks the current thread indefinitely to keep the background listener
+        # alive. Returns when interrupted (e.g. Ctrl-C).
+        # @return [void]
+        def wait
+          sleep
+        rescue Interrupt
+          nil
+        end
+
+        # Stops serving and closes the connection.
+        # @return [void]
+        def stop
+          @connection&.close
+          @connection = nil
+        end
+
+        private
+
+        # @return [Boolean] whether the served database is in-memory
+        def memory?
+          DuckdbAdapter::MEMORY_MODE_KEYS.include?(database)
+        end
+
+        # Single-quotes and escapes a value for inline SQL, matching the adapter's
+        # quoting of string literals.
+        # @param value [Object] the value to quote
+        # @return [String] the quoted literal
+        def quote(value)
+          "'#{value.to_s.gsub("'", "''")}'"
+        end
+      end
+    end
+  end
+end

--- a/lib/active_record/connection_adapters/duckdb/schema_statements.rb
+++ b/lib/active_record/connection_adapters/duckdb/schema_statements.rb
@@ -64,8 +64,11 @@ module ActiveRecord
             create_sequence_safely(sequence_name, table_name, start_with: start_with)
           end
 
-          # Store sequence info for later use during table creation
-          @pending_sequence_default = ({ table: table_name, column: pk_column_name, sequence: sequence_name } if needs_sequence_default && sequence_name && pk_column_name)
+          # Store sequence info for later use during table creation.
+          # In quack mode we deliberately do NOT inject a DEFAULT nextval() column
+          # default: a function-valued default breaks quack ATTACH. The id is instead
+          # prefetched from the sequence via quack_query() on insert (prefetch_primary_key?).
+          @pending_sequence_default = ({ table: table_name, column: pk_column_name, sequence: sequence_name } if needs_sequence_default && sequence_name && pk_column_name && !quack_enabled?)
 
           begin
             # Now create the table with Rails handling the standard creation
@@ -89,6 +92,10 @@ module ActiveRecord
           sql = "CREATE SEQUENCE #{quote_table_name(sequence_name)}"
           sql << " START #{start_with.to_i}" if start_with != 1
           sql << " INCREMENT #{increment_by.to_i}" if increment_by != 1
+          # CREATE SEQUENCE is not implemented over a quack ATTACH, so route it to the
+          # server via quack_query() where the sequence must actually live.
+          return quack_query_exec(sql) if quack_enabled?
+
           execute(sql, 'Create Sequence')
         end
 
@@ -107,6 +114,13 @@ module ActiveRecord
         # @param sequence_name [String] The name of the sequence to check
         # @return [Boolean] true if the sequence exists, false otherwise
         def sequence_exists?(sequence_name)
+          # Over quack the sequence lives on the server and isn't visible through the
+          # attached catalog; check for it server-side via quack_query() instead.
+          if quack_enabled?
+            count = quack_query_value("SELECT COUNT(*) FROM duckdb_sequences() WHERE sequence_name = #{quote(sequence_name)}")
+            return count.to_i.positive?
+          end
+
           # Try to get next value from sequence in a way that doesn't consume it
           # Use a transaction that we can rollback to avoid side effects
           transaction do
@@ -545,8 +559,11 @@ module ActiveRecord
           # Parse null constraint (DuckDB: not_null=1 means NOT NULL)
           is_null = !not_null.in?([1, true])
 
-          # Detect auto-increment columns
-          is_integer_pk = pk && formatted_type.upcase.in?(%w[INTEGER BIGINT])
+          # Detect auto-increment columns. Over quack the integer PK is NOT
+          # auto-incremented by the database (no DEFAULT nextval); it is prefetched and
+          # supplied in the INSERT. Marking it auto_increment would make Rails treat the
+          # column as auto-populated and discard the prefetched value.
+          is_integer_pk = pk && formatted_type.upcase.in?(%w[INTEGER BIGINT]) && !quack_enabled?
 
           {
             name: column_name.to_s,
@@ -557,15 +574,21 @@ module ActiveRecord
             collation: collation_name.to_s.presence,
             comment: comment.to_s.presence,
             auto_increment: is_integer_pk,
-            rowid: pk && column_name == 'id'
+            # Over quack the id is prefetched, not auto-incremented by the DB, so it must
+            # not be treated as a rowid (which also marks the column auto-populated).
+            rowid: pk && column_name == 'id' && !quack_enabled?
           }
         end
 
         # Parses column default, separating static values from sequence functions.
         # @return [Array<Object, String>] [default_value, default_function]
         def parse_column_default(table_name, column_name, column_default, formatted_type, pk)
-          # Integer primary key named 'id' - assume sequence exists
-          if pk&.in?([true, 1]) && formatted_type.upcase.in?(%w[INTEGER BIGINT]) && column_name == 'id'
+          # Integer primary key named 'id' - assume sequence exists.
+          # In quack mode the column genuinely has no DEFAULT (it can't -- a function
+          # default breaks quack ATTACH), and the id is prefetched instead. Synthesizing
+          # a nextval default_function here would mark the column auto-populated and
+          # defeat the prefetch, so skip it over quack.
+          if pk&.in?([true, 1]) && formatted_type.upcase.in?(%w[INTEGER BIGINT]) && column_name == 'id' && !quack_enabled?
             # Build the sequence name and quote it properly for the nextval expression
             seq_name = "#{table_name}_#{column_name}_seq"
             [nil, "nextval(#{quote(seq_name)})"]

--- a/lib/active_record/connection_adapters/duckdb_adapter.rb
+++ b/lib/active_record/connection_adapters/duckdb_adapter.rb
@@ -13,6 +13,7 @@ require 'active_record/connection_adapters/duckdb/schema_creation'
 require 'active_record/connection_adapters/duckdb/schema_statements'
 require 'active_record/connection_adapters/duckdb/schema_definitions'
 require 'active_record/connection_adapters/duckdb/schema_dumper'
+require 'active_record/connection_adapters/duckdb/quack_server'
 
 # Inspired by the SQLite adapter
 # duckdb: https://github.com/duckdb/duckdb-ruby
@@ -820,9 +821,7 @@ module ActiveRecord
         name = cfg[:as].presence || 'remote'
         raw_connection.execute('INSTALL quack')
         raw_connection.execute('LOAD quack')
-
         raw_connection.execute("CREATE SECRET (TYPE quack, TOKEN #{quote(cfg[:token])}, SCOPE #{quote(url)})") if cfg[:token].present?
-
         raw_connection.execute("ATTACH #{quote(url)} AS #{name} (TYPE quack)")
         raw_connection.execute("USE #{name}") unless cfg[:use] == false
       end

--- a/lib/active_record/connection_adapters/duckdb_adapter.rb
+++ b/lib/active_record/connection_adapters/duckdb_adapter.rb
@@ -256,17 +256,20 @@ module ActiveRecord
       end
 
       # Indicates whether the adapter supports INSERT...RETURNING syntax
-      # DuckLake does NOT support INSERT...RETURNING, so we check for DuckLake mode
-      # @return [Boolean] true for regular DuckDB, false for DuckLake
+      # DuckLake does NOT support INSERT...RETURNING. Over quack, RETURNING is broken
+      # (it returns a row count, not the projected columns) and unnecessary since the
+      # primary key is prefetched, so it is disabled there too.
+      # @return [Boolean] true for regular DuckDB, false for DuckLake or quack
       def use_insert_returning?
-        !ducklake?
+        !ducklake? && !quack_enabled?
       end
 
       # Indicates whether the adapter supports INSERT RETURNING for Rails 8
-      # DuckLake does NOT support INSERT...RETURNING, so we check for DuckLake mode
-      # @return [Boolean] true for regular DuckDB, false for DuckLake
+      # DuckLake does NOT support INSERT...RETURNING; neither does quack (see
+      # use_insert_returning?), where the primary key is prefetched instead.
+      # @return [Boolean] true for regular DuckDB, false for DuckLake or quack
       def supports_insert_returning?
-        !ducklake?
+        !ducklake? && !quack_enabled?
       end
 
       # Detects if the current database is a DuckLake database
@@ -340,11 +343,23 @@ module ActiveRecord
       # @raise [SavepointsNotSupported] always raises since DuckDB doesn't support savepoints
       def release_savepoint(_name = nil) = raise SavepointsNotSupported
 
-      # Determines if primary key should be prefetched before insert
+      # Determines if primary key should be prefetched before insert.
+      #
+      # Normally false: DuckDB fills integer primary keys from a DEFAULT nextval()
+      # sequence, so the value is excluded from INSERT. Over a quack connection that
+      # DEFAULT can't exist (a function-valued column default breaks quack ATTACH, and
+      # the client can't reach the server's sequence through the attached catalog), so
+      # in quack mode we prefetch the id via quack_query() and include it in the INSERT.
       # @param _table_name [String] The table name (unused)
-      # @return [Boolean] always returns false to exclude auto-increment columns from INSERT
+      # @return [Boolean] true in quack mode, false otherwise
       def prefetch_primary_key?(_table_name)
-        false
+        quack_enabled?
+      end
+
+      # Whether this connection is a quack client (a remote DuckDB server).
+      # @return [Boolean] true if a quack: block configured a remote connection
+      def quack_enabled?
+        !@quack_url.nil?
       end
 
       # Returns the sequence name for a serial column
@@ -489,11 +504,103 @@ module ActiveRecord
         end
       end
 
-      # Generates SQL for getting the next sequence value
+      # Returns the next value for a sequence.
+      #
+      # In quack mode this is called by Rails' prefetch path (see prefetch_primary_key?)
+      # and MUST return the actual next integer, which is fetched from the server via
+      # quack_query() (the sequence isn't visible through the attached catalog). Outside
+      # quack mode it returns the SQL expression string used inline as a column default.
       # @param sequence_name [String] The name of the sequence
-      # @return [String] SQL expression for next sequence value
+      # @return [Integer, String] the next value (quack mode) or a nextval() SQL expression
       def next_sequence_value(sequence_name)
+        return quack_query_value("SELECT nextval(#{quote(sequence_name)})") if quack_enabled?
+
         "nextval(#{quote(sequence_name)})"
+      end
+
+      # Runs a single SQL statement on the remote quack server via quack_query() and
+      # returns the first column of the first row. Used for sequence operations that
+      # the attached catalog cannot serve (nextval, sequence existence checks).
+      # @param sql [String] the SQL to execute server-side
+      # @return [Object, nil] the first scalar of the result, or nil
+      def quack_query_value(sql)
+        result = raw_connection.query("SELECT * FROM quack_query(#{quote(@quack_url)}, $QUACKSQL$#{sql}$QUACKSQL$)")
+        result.to_a.first&.first
+      end
+
+      # Runs a statement on the remote quack server via quack_query() for its side
+      # effect (e.g. CREATE SEQUENCE, which is not implemented over a quack ATTACH).
+      # A trailing SELECT guarantees quack_query() has a result set to return.
+      # @param sql [String] the SQL to execute server-side
+      # @return [void]
+      def quack_query_exec(sql)
+        raw_connection.query("SELECT * FROM quack_query(#{quote(@quack_url)}, $QUACKSQL$#{sql}; SELECT 1$QUACKSQL$)")
+        nil
+      end
+
+      # Inserts a record and returns its id.
+      #
+      # Over quack we can't rely on INSERT...RETURNING (it returns a row count, not the
+      # projected columns). The primary key is prefetched (prefetch_primary_key?), so it is
+      # already present in the INSERT and known to Rails as +id_value+. We run the insert
+      # without RETURNING and hand that prefetched value straight back, matching the shape
+      # Rails expects: an array when returning columns were requested, a scalar otherwise.
+      # @return [Object, Array, nil] the inserted id (array-wrapped when returning requested)
+      def insert(arel, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = [], returning: nil)
+        return super unless quack_enabled?
+
+        sql, binds = to_sql_and_binds(arel, binds)
+        exec_insert(sql, name, binds, pk, sequence_name)
+        returning.blank? ? id_value : Array(id_value)
+      end
+
+      # Executes an UPDATE and returns the number of affected rows.
+      # A quack ATTACH cannot UPDATE the remote table directly ("Can only update base
+      # table"), so the statement is run server-side via quack_query(), which returns the
+      # affected-row count. See quack_exec_write.
+      # @return [Integer] number of rows affected
+      def exec_update(sql, name = nil, binds = [])
+        return super unless quack_enabled?
+
+        quack_exec_write(sql, name, binds)
+      end
+
+      # Executes a DELETE and returns the number of affected rows. Routed via quack_query()
+      # over quack for the same reason as exec_update. Defined explicitly rather than aliased
+      # so bare +super+ resolves to the parent DELETE path (aliases keep the original name).
+      # @return [Integer] number of rows affected
+      def exec_delete(sql, name = nil, binds = [])
+        return super unless quack_enabled?
+
+        quack_exec_write(sql, name, binds)
+      end
+
+      # Runs a write statement (UPDATE/DELETE) on the remote quack server via quack_query()
+      # and returns the affected-row count it reports. quack_query() takes a SQL string, so
+      # bind parameters are inlined first.
+      # @param sql [String] the statement with '?' placeholders
+      # @param name [String, nil] log label
+      # @param binds [Array] bind parameters
+      # @return [Integer] number of rows affected
+      def quack_exec_write(sql, name, binds)
+        full_sql = quack_inline_binds(sql, binds)
+        log(sql, name, binds) do
+          quack_query_value(full_sql).to_i
+        end
+      end
+
+      # Inlines bind parameters into a SQL string, replacing each '?' placeholder in order
+      # with its quoted value. Rails-generated UPDATE/DELETE statements only use '?' as
+      # placeholders (literals are passed as binds), so positional replacement is safe here.
+      # @param sql [String] the statement with '?' placeholders
+      # @param binds [Array] bind parameters
+      # @return [String] the statement with values inlined
+      def quack_inline_binds(sql, binds)
+        casted = type_casted_binds(binds)
+        return sql if casted.empty?
+
+        index = -1
+        sql.gsub('?') { quote(casted[index += 1]) }
       end
 
       # Generates default sequence name following PostgreSQL/Oracle conventions
@@ -824,6 +931,13 @@ module ActiveRecord
         raw_connection.execute("CREATE SECRET (TYPE quack, TOKEN #{quote(cfg[:token])}, SCOPE #{quote(url)})") if cfg[:token].present?
         raw_connection.execute("ATTACH #{quote(url)} AS #{name} (TYPE quack)")
         raw_connection.execute("USE #{name}") unless cfg[:use] == false
+
+        # Remember the remote URI so sequence/prefetch operations can reach the
+        # server through the quack_query() side-channel. Over a quack ATTACH the
+        # remote catalog exposes tables (queryable) but NOT sequences, and
+        # CREATE SEQUENCE is not implemented; quack_query() runs SQL server-side
+        # where the sequence actually lives.
+        @quack_url = url
       end
 
       # Sets the active database using USE statement

--- a/lib/active_record/connection_adapters/duckdb_adapter.rb
+++ b/lib/active_record/connection_adapters/duckdb_adapter.rb
@@ -401,6 +401,7 @@ module ActiveRecord
         apply_settings
         create_secrets
         attach_databases
+        configure_quack
         use_database
         lock_configuration
       end
@@ -770,6 +771,60 @@ module ActiveRecord
 
           raw_connection.execute(sql)
         end
+      end
+
+      # Configures a remote quack (client/server) connection.
+      #
+      # quack is a DuckDB core extension (DuckDB >= 1.5.3) that lets an embedded
+      # DuckDB act as a client to a remote DuckDB server over the +quack:+ protocol.
+      # This is entirely opt-in and off by default: when no +quack:+ block is present
+      # in the database configuration, this method is a no-op and standalone/in-memory
+      # behavior is unchanged.
+      #
+      # The block is self-contained -- it installs and loads the quack extension itself,
+      # so developers do not need to add +quack+ to the +extensions:+ list separately.
+      # INSTALL is idempotent (a no-op when quack is already present) and, being an
+      # explicit install of a core extension, does not require autoinstall_known_extensions,
+      # so the adapter's secure defaults remain intact.
+      #
+      # Supported +quack:+ keys:
+      #   url:   (required) the remote server URI, e.g. "quack:host:9494"
+      #   token: (optional) auth token; registered as a scoped quack SECRET when present
+      #   as:    (optional) ATTACH alias, defaults to "remote"
+      #   use:   (optional) whether to USE the attached database, defaults to true
+      #
+      # A blank block (nil, {}, or one whose keys are all blank) is treated as disabled.
+      # A block that supplies other keys but omits +url+ is a misconfiguration and raises,
+      # rather than emitting an invalid ATTACH statement.
+      #
+      # @return [void]
+      # @raise [ArgumentError] if a non-blank quack block is missing a url
+      def configure_quack
+        cfg = @config[:quack]
+        return if cfg.blank? # no quack: key, or an empty block -> disabled
+
+        # Drop keys whose value is nil or a blank/whitespace string so valueless
+        # YAML keys don't produce `TOKEN NULL` / `ATTACH NULL`. Booleans are kept
+        # deliberately: `use: false` is meaningful and must survive (false.blank? is true).
+        cfg = cfg.transform_keys(&:to_sym).reject do |_key, value|
+          value.nil? || (value.is_a?(String) && value&.strip&.blank?)
+        end
+        return if cfg.blank? # every key was blank -> disabled
+
+        url = cfg[:url]
+        raise ArgumentError, <<~MSG if url.blank?
+          DuckDB quack configuration is missing a `url` (e.g. "quack:host:9494").
+          Provide `quack.url` or remove the `quack:` block from database.yml.
+        MSG
+
+        name = cfg[:as].presence || 'remote'
+        raw_connection.execute('INSTALL quack')
+        raw_connection.execute('LOAD quack')
+
+        raw_connection.execute("CREATE SECRET (TYPE quack, TOKEN #{quote(cfg[:token])}, SCOPE #{quote(url)})") if cfg[:token].present?
+
+        raw_connection.execute("ATTACH #{quote(url)} AS #{name} (TYPE quack)")
+        raw_connection.execute("USE #{name}") unless cfg[:use] == false
       end
 
       # Sets the active database using USE statement

--- a/lib/active_record/tasks/duckdb_quack.rake
+++ b/lib/active_record/tasks/duckdb_quack.rake
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'active_record/connection_adapters/duckdb/quack_server'
+
+namespace :duckdb do
+  namespace :quack do
+    desc 'Start a DuckDB quack server so multiple client processes can share one ' \
+         'writable database. Env: DATABASE, BIND, QUACK_TOKEN, ' \
+         'QUACK_EXTENSIONS (comma-separated), QUACK_ALLOW_OTHER_HOSTNAME=1'
+    task :serve do
+      server = ActiveRecord::ConnectionAdapters::Duckdb::QuackServer.new(
+        database: ENV['DATABASE'] || ':memory:',
+        bind: ENV.fetch('BIND', nil),
+        token: ENV.fetch('QUACK_TOKEN', nil),
+        extensions: ENV['QUACK_EXTENSIONS'].to_s.split(',').map(&:strip).reject(&:empty?),
+        allow_other_hostname: %w[1 true yes].include?(ENV['QUACK_ALLOW_OTHER_HOSTNAME'].to_s.downcase)
+      )
+
+      server.start
+      warn "DuckDB quack server: serving '#{server.database}' on '#{server.bind}' (Ctrl-C to stop)"
+      warn 'WARNING: no token set; the server generated one at startup and all queries are allowed.' unless server.token
+
+      server.wait
+    ensure
+      server&.stop
+    end
+  end
+end

--- a/lib/active_record/tasks/duckdb_quack.rake
+++ b/lib/active_record/tasks/duckdb_quack.rake
@@ -17,7 +17,8 @@ namespace :duckdb do
       )
 
       server.start
-      warn "DuckDB quack server: serving '#{server.database}' on '#{server.bind}' (Ctrl-C to stop)"
+      warn "DuckDB quack server: serving '#{server.database}' on '#{server.bind}' " \
+           '(stop with Ctrl-C, or SIGTERM from kill/Docker/systemd)'
       warn 'WARNING: no token set; the server generated one at startup and all queries are allowed.' unless server.token
 
       server.wait

--- a/lib/activerecord-duckdb.rb
+++ b/lib/activerecord-duckdb.rb
@@ -26,6 +26,7 @@ if defined?(Rails)
         # @return [void]
         rake_tasks do
           require 'active_record/tasks/duckdb_database_tasks'
+          load File.expand_path('active_record/tasks/duckdb_quack.rake', __dir__)
         end
 
         # Sets up DuckDB adapter integration when ActiveRecord loads

--- a/spec/active_record/connection_adapters/duckdb/quack_integer_pk_spec.rb
+++ b/spec/active_record/connection_adapters/duckdb/quack_integer_pk_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Unit specs for the integer-primary-key support over a quack connection.
+#
+# The full behavior (migrate + CRUD against a live quack server with integer PKs)
+# requires a running remote DuckDB server, which the unit suite avoids. These specs
+# exercise the individual decisions the adapter makes in quack mode by allocating a
+# bare adapter, flipping @quack_url, and mocking the connection boundary. The
+# end-to-end path is verified manually against DuckDB >= 1.5.3.
+RSpec.describe 'DuckDB quack integer primary key support' do
+  # An allocated adapter with quack mode on/off and a minimal config.
+  def build_adapter(quack: true)
+    adapter = ActiveRecord::ConnectionAdapters::DuckdbAdapter.allocate
+    adapter.instance_variable_set(:@quack_url, quack ? 'quack:localhost:9494' : nil)
+    adapter.instance_variable_set(:@config, {})
+    adapter
+  end
+
+  describe '#quack_enabled?' do
+    it 'is true when a quack url is set' do
+      expect(build_adapter(quack: true).quack_enabled?).to be true
+    end
+
+    it 'is false otherwise' do
+      expect(build_adapter(quack: false).quack_enabled?).to be false
+    end
+  end
+
+  describe '#prefetch_primary_key?' do
+    it 'prefetches in quack mode (no DB default is possible over quack)' do
+      expect(build_adapter(quack: true).prefetch_primary_key?('users')).to be true
+    end
+
+    it 'does not prefetch normally (DuckDB fills the id from a sequence default)' do
+      expect(build_adapter(quack: false).prefetch_primary_key?('users')).to be false
+    end
+  end
+
+  describe 'INSERT ... RETURNING support' do
+    it 'is disabled over quack (RETURNING is unreliable there)' do
+      adapter = build_adapter(quack: true)
+      allow(adapter).to receive(:ducklake?).and_return(false)
+      expect(adapter.supports_insert_returning?).to be false
+      expect(adapter.use_insert_returning?).to be false
+    end
+
+    it 'is enabled for a regular DuckDB connection' do
+      adapter = build_adapter(quack: false)
+      allow(adapter).to receive(:ducklake?).and_return(false)
+      expect(adapter.supports_insert_returning?).to be true
+    end
+  end
+
+  describe '#next_sequence_value' do
+    it 'returns the actual next integer from the server in quack mode' do
+      adapter = build_adapter(quack: true)
+      allow(adapter).to receive(:quack_query_value).with("SELECT nextval('users_id_seq')").and_return(7)
+      expect(adapter.next_sequence_value('users_id_seq')).to eq(7)
+    end
+
+    it 'returns a nextval() SQL expression outside quack mode' do
+      expect(build_adapter(quack: false).next_sequence_value('users_id_seq'))
+        .to eq("nextval('users_id_seq')")
+    end
+  end
+
+  describe '#quack_inline_binds' do
+    it 'replaces ? placeholders in order with quoted bind values' do
+      adapter = build_adapter(quack: true)
+      allow(adapter).to receive(:type_casted_binds).and_return(['bob', 5])
+      expect(adapter.quack_inline_binds('UPDATE t SET name = ? WHERE id = ?', :binds))
+        .to eq("UPDATE t SET name = 'bob' WHERE id = 5")
+    end
+
+    it 'escapes single quotes in string binds' do
+      adapter = build_adapter(quack: true)
+      allow(adapter).to receive(:type_casted_binds).and_return(["O'Brien"])
+      expect(adapter.quack_inline_binds('UPDATE t SET name = ?', :binds))
+        .to eq("UPDATE t SET name = 'O''Brien'")
+    end
+
+    it 'returns the SQL unchanged when there are no binds' do
+      adapter = build_adapter(quack: true)
+      allow(adapter).to receive(:type_casted_binds).and_return([])
+      expect(adapter.quack_inline_binds('DELETE FROM t WHERE id = 1', [])).to eq('DELETE FROM t WHERE id = 1')
+    end
+  end
+
+  describe '#exec_update / #exec_delete in quack mode' do
+    it 'routes UPDATE through quack_query and returns the affected-row count' do
+      adapter = build_adapter(quack: true)
+      allow(adapter).to receive(:type_casted_binds).and_return([])
+      allow(adapter).to receive(:log).and_yield
+      allow(adapter).to receive(:quack_query_value).with("UPDATE users SET name = 'x'").and_return(4)
+      expect(adapter.exec_update("UPDATE users SET name = 'x'")).to eq(4)
+    end
+
+    it 'routes DELETE through quack_query and returns the affected-row count' do
+      adapter = build_adapter(quack: true)
+      allow(adapter).to receive(:type_casted_binds).and_return([])
+      allow(adapter).to receive(:log).and_yield
+      allow(adapter).to receive(:quack_query_value).with('DELETE FROM users WHERE id = 2').and_return(1)
+      expect(adapter.exec_delete('DELETE FROM users WHERE id = 2')).to eq(1)
+    end
+  end
+
+  describe '#insert in quack mode' do
+    it 'runs the insert and hands back the prefetched id (array when returning requested)' do
+      adapter = build_adapter(quack: true)
+      allow(adapter).to receive(:to_sql_and_binds).and_return(['INSERT INTO users ...', []])
+      allow(adapter).to receive(:exec_insert)
+      expect(adapter.insert(:arel, 'Create', 'id', 42, nil, [], returning: ['id'])).to eq([42])
+    end
+
+    it 'hands back the prefetched id as a scalar when no returning columns are requested' do
+      adapter = build_adapter(quack: true)
+      allow(adapter).to receive(:to_sql_and_binds).and_return(['INSERT INTO users ...', []])
+      allow(adapter).to receive(:exec_insert)
+      expect(adapter.insert(:arel, 'Create', 'id', 42, nil, [], returning: nil)).to eq(42)
+    end
+  end
+end

--- a/spec/active_record/connection_adapters/duckdb/quack_server_spec.rb
+++ b/spec/active_record/connection_adapters/duckdb/quack_server_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Specs for the optional quack server launcher.
+#
+# A quack server needs a long-lived process and a real network listener, which
+# isn't appropriate for the unit suite, so these specs assert on the SQL the
+# server emits and on how it opens the database (mocking DuckDB), rather than
+# actually binding a port. The emitted CALL quack_serve(...) should be verified
+# end-to-end against DuckDB >= 1.5.3 when a server environment is available.
+RSpec.describe ActiveRecord::ConnectionAdapters::Duckdb::QuackServer do
+  describe '#serve_sql' do
+    it 'uses the default bind and no params when nothing is configured' do
+      expect(described_class.new.serve_sql).to eq("CALL quack_serve('quack:localhost:9494')")
+    end
+
+    it 'honors a custom bind URI' do
+      server = described_class.new(bind: 'quack:0.0.0.0:9494')
+      expect(server.serve_sql).to eq("CALL quack_serve('quack:0.0.0.0:9494')")
+    end
+
+    it 'includes the token as a named parameter when given' do
+      server = described_class.new(token: 'super_secret')
+      expect(server.serve_sql).to eq("CALL quack_serve('quack:localhost:9494', token => 'super_secret')")
+    end
+
+    it 'includes allow_other_hostname when enabled' do
+      server = described_class.new(bind: 'quack:0.0.0.0:9494', allow_other_hostname: true)
+      expect(server.serve_sql).to eq("CALL quack_serve('quack:0.0.0.0:9494', allow_other_hostname => true)")
+    end
+
+    it 'combines token and allow_other_hostname in order' do
+      server = described_class.new(bind: 'quack:0.0.0.0:9494', token: 'abcd', allow_other_hostname: true)
+      expect(server.serve_sql).to eq(
+        "CALL quack_serve('quack:0.0.0.0:9494', token => 'abcd', allow_other_hostname => true)"
+      )
+    end
+
+    it 'escapes single quotes in the token' do
+      server = described_class.new(token: "a'bc")
+      expect(server.serve_sql).to eq("CALL quack_serve('quack:localhost:9494', token => 'a''bc')")
+    end
+  end
+
+  describe '#startup_sql' do
+    it 'installs and loads quack, then serves' do
+      expect(described_class.new.startup_sql).to eq(
+        ['INSTALL quack', 'LOAD quack', "CALL quack_serve('quack:localhost:9494')"]
+      )
+    end
+
+    it 'installs and loads any extra extensions before serving' do
+      server = described_class.new(extensions: %w[httpfs postgres_scanner])
+      expect(server.startup_sql).to eq(
+        [
+          'INSTALL quack', 'LOAD quack',
+          'INSTALL httpfs', 'LOAD httpfs',
+          'INSTALL postgres_scanner', 'LOAD postgres_scanner',
+          "CALL quack_serve('quack:localhost:9494')"
+        ]
+      )
+    end
+  end
+
+  describe 'defaults and normalization' do
+    it 'defaults to an in-memory database' do
+      expect(described_class.new.database).to eq(':memory:')
+    end
+
+    it 'falls back to the default bind when bind is blank' do
+      expect(described_class.new(bind: '').bind).to eq('quack:localhost:9494')
+    end
+
+    it 'treats a blank token as no token' do
+      expect(described_class.new(token: '').token).to be_nil
+    end
+
+    it 'raises when a non-blank token is shorter than the minimum length' do
+      expect { described_class.new(token: 'abc') }
+        .to raise_error(ArgumentError, /at least 4 characters/)
+    end
+
+    it 'accepts a token at the minimum length' do
+      expect(described_class.new(token: 'abcd').token).to eq('abcd')
+    end
+  end
+
+  describe '#start' do
+    let(:raw) { instance_double(DuckDB::Connection, execute: nil, close: nil) }
+    let(:db) { instance_double(DuckDB::Database, connect: raw) }
+
+    it 'opens an in-memory database with no path' do
+      allow(DuckDB::Database).to receive(:open).with(no_args).and_return(db)
+      described_class.new(database: ':memory:').start
+      expect(DuckDB::Database).to have_received(:open).with(no_args)
+    end
+
+    it 'opens a file database with the given path' do
+      allow(DuckDB::Database).to receive(:open).with('db/shared.duckdb').and_return(db)
+      described_class.new(database: 'db/shared.duckdb').start
+      expect(DuckDB::Database).to have_received(:open).with('db/shared.duckdb')
+    end
+
+    it 'executes each startup statement in order on the connection' do
+      allow(DuckDB::Database).to receive(:open).and_return(db)
+      server = described_class.new(token: 'super_secret')
+      server.start
+
+      expect(raw).to have_received(:execute).with('INSTALL quack').ordered
+      expect(raw).to have_received(:execute).with('LOAD quack').ordered
+      expect(raw).to have_received(:execute).with(
+        "CALL quack_serve('quack:localhost:9494', token => 'super_secret')"
+      ).ordered
+    end
+
+    it 'exposes the serving connection' do
+      allow(DuckDB::Database).to receive(:open).and_return(db)
+      server = described_class.new.start
+      expect(server.connection).to eq(raw)
+    end
+  end
+
+  describe '#stop' do
+    it 'closes the connection and clears it' do
+      raw = instance_double(DuckDB::Connection, execute: nil, close: nil)
+      db = instance_double(DuckDB::Database, connect: raw)
+      allow(DuckDB::Database).to receive(:open).and_return(db)
+
+      server = described_class.new.start
+      server.stop
+
+      expect(raw).to have_received(:close)
+      expect(server.connection).to be_nil
+    end
+  end
+end

--- a/spec/active_record/connection_adapters/duckdb/quack_server_spec.rb
+++ b/spec/active_record/connection_adapters/duckdb/quack_server_spec.rb
@@ -122,16 +122,32 @@ RSpec.describe ActiveRecord::ConnectionAdapters::Duckdb::QuackServer do
   end
 
   describe '#stop' do
-    it 'closes the connection and clears it' do
+    it 'stops each served uri via quack_stop, then closes and clears the connection' do
       raw = instance_double(DuckDB::Connection, execute: nil, close: nil)
+      # Closing the connection alone does not stop the listener, so stop must call
+      # quack_stop() for every uri quack_server_list() reports.
+      allow(raw).to receive(:query).and_return([['quack:localhost:9494']])
       db = instance_double(DuckDB::Database, connect: raw)
       allow(DuckDB::Database).to receive(:open).and_return(db)
 
       server = described_class.new.start
       server.stop
 
+      expect(raw).to have_received(:query).with('SELECT * FROM quack_server_list()')
+      expect(raw).to have_received(:query).with("CALL quack_stop('quack:localhost:9494')")
       expect(raw).to have_received(:close)
       expect(server.connection).to be_nil
+    end
+
+    it 'tolerates a server that is no longer serving' do
+      raw = instance_double(DuckDB::Connection, execute: nil, close: nil)
+      allow(raw).to receive(:query).and_raise(DuckDB::Error)
+      db = instance_double(DuckDB::Database, connect: raw)
+      allow(DuckDB::Database).to receive(:open).and_return(db)
+
+      server = described_class.new.start
+      expect { server.stop }.not_to raise_error
+      expect(raw).to have_received(:close)
     end
   end
 end

--- a/spec/active_record/connection_adapters/duckdb/quack_spec.rb
+++ b/spec/active_record/connection_adapters/duckdb/quack_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Specs for the optional quack (client/server) remote protocol configuration.
+#
+# quack requires a live remote DuckDB server, which isn't available in the test
+# suite, so these specs exercise `configure_quack` in isolation: they mock the
+# raw connection and assert on the exact SQL emitted (and on the guard/validation
+# behavior) rather than connecting to a real server. When a server is available,
+# the emitted SQL should be verified end-to-end against DuckDB >= 1.5.3.
+RSpec.describe 'DuckDB quack remote protocol configuration' do
+  # Builds an allocated adapter with the given config and a fake raw connection
+  # that records every SQL statement executed, then runs configure_quack.
+  #
+  # @param quack [Object] the value for the :quack config key (or :none to omit it)
+  # @return [Array<String>] SQL statements executed, in order
+  def executed_sql_for(quack: :none)
+    adapter = ActiveRecord::ConnectionAdapters::DuckdbAdapter.allocate
+    config = { database: ':memory:' }
+    config[:quack] = quack unless quack == :none
+    adapter.instance_variable_set(:@config, config)
+
+    executed = []
+    raw = instance_double(DuckDB::Connection)
+    allow(raw).to receive(:execute) { |sql| executed << sql }
+    allow(adapter).to receive(:raw_connection).and_return(raw)
+
+    adapter.send(:configure_quack)
+    executed
+  end
+
+  context 'when the quack block is absent or blank (disabled)' do
+    it 'does nothing when there is no quack key' do
+      expect(executed_sql_for).to be_empty
+    end
+
+    it 'does nothing when the quack block is nil (empty YAML key)' do
+      expect(executed_sql_for(quack: nil)).to be_empty
+    end
+
+    it 'does nothing when the quack block is an empty hash' do
+      expect(executed_sql_for(quack: {})).to be_empty
+    end
+
+    it 'does nothing when every key is blank (valueless YAML keys)' do
+      expect(executed_sql_for(quack: { url: nil, token: '', as: nil })).to be_empty
+    end
+  end
+
+  context 'when the quack block is present but invalid' do
+    it 'raises when url is missing but other keys are given' do
+      expect { executed_sql_for(quack: { token: 'abc' }) }
+        .to raise_error(ArgumentError, /missing a `url`/)
+    end
+
+    it 'raises when url is blank but other keys are given' do
+      expect { executed_sql_for(quack: { url: '', token: 'abc' }) }
+        .to raise_error(ArgumentError, /missing a `url`/)
+    end
+  end
+
+  context 'with a minimal valid block (url only)' do
+    subject(:sql) { executed_sql_for(quack: { url: 'quack:localhost:9494' }) }
+
+    it 'installs and loads the quack extension itself' do
+      expect(sql).to start_with('INSTALL quack', 'LOAD quack')
+    end
+
+    it 'does not create a secret when no token is given' do
+      expect(sql).not_to include(a_string_matching(/CREATE SECRET/))
+    end
+
+    it 'attaches the remote database with the default alias and TYPE quack' do
+      expect(sql).to include("ATTACH 'quack:localhost:9494' AS remote (TYPE quack)")
+    end
+
+    it 'switches to the attached database by default' do
+      expect(sql).to include('USE remote')
+    end
+  end
+
+  context 'with a token' do
+    subject(:sql) do
+      executed_sql_for(quack: { url: 'quack:localhost:9494', token: 'super_secret' })
+    end
+
+    it 'creates a scoped quack secret before attaching' do
+      secret = "CREATE SECRET (TYPE quack, TOKEN 'super_secret', SCOPE 'quack:localhost:9494')"
+      attach = "ATTACH 'quack:localhost:9494' AS remote (TYPE quack)"
+      expect(sql.index(secret)).to be < sql.index(attach)
+    end
+  end
+
+  context 'with a custom alias' do
+    subject(:sql) do
+      executed_sql_for(quack: { url: 'quack:localhost:9494', as: 'warehouse' })
+    end
+
+    it 'attaches under the given alias' do
+      expect(sql).to include("ATTACH 'quack:localhost:9494' AS warehouse (TYPE quack)")
+    end
+
+    it 'switches to the given alias' do
+      expect(sql).to include('USE warehouse')
+    end
+  end
+
+  context 'when use is false' do
+    subject(:sql) do
+      executed_sql_for(quack: { url: 'quack:localhost:9494', use: false })
+    end
+
+    it 'attaches the remote database' do
+      expect(sql).to include("ATTACH 'quack:localhost:9494' AS remote (TYPE quack)")
+    end
+
+    it 'does not switch the active database' do
+      expect(sql).not_to include(a_string_matching(/\AUSE /))
+    end
+  end
+
+  context 'with string keys (as parsed from database.yml)' do
+    subject(:sql) do
+      executed_sql_for(quack: { 'url' => 'quack:localhost:9494', 'token' => 'super_secret' })
+    end
+
+    it 'normalizes string keys and emits the expected statements' do
+      expect(sql).to include(
+        "CREATE SECRET (TYPE quack, TOKEN 'super_secret', SCOPE 'quack:localhost:9494')",
+        "ATTACH 'quack:localhost:9494' AS remote (TYPE quack)",
+        'USE remote'
+      )
+    end
+  end
+
+  it 'escapes single quotes in the token to prevent broken/injected SQL' do
+    sql = executed_sql_for(quack: { url: 'quack:localhost:9494', token: "a'b" })
+    expect(sql).to include("CREATE SECRET (TYPE quack, TOKEN 'a''b', SCOPE 'quack:localhost:9494')")
+  end
+end


### PR DESCRIPTION
**Summary:**
Address issue: https://github.com/tarellel/activerecord-duckdb/issues/8

* Add ability to make Quack queries, and adjusting 
* Add ability to create entry data through quack
  * If Quack is specified ensure the quack extension is automatically loaded
  * `nextval` does not work through quack, so a pre-select query must be made
  * If using Quack protocol adjust queries to use QUACK source
* Add ability to start/stop a quack server through rake task `bundle exec rake duckdb:quack:serve`

CC: @ukazap

